### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ from ParamikoMock import SSHMockEnvron, SSHCommandMock
 from unittest.mock import patch
 import paramiko
 
+def example_function_sftp_read():
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    # Some example of connection
+    client.connect('some_host_4',
+                    port=22,
+                    username='root',
+                    password='root',
+                    banner_timeout=10)
+    # Some example of a remote file write
+    sftp = client.open_sftp()
+    file = sftp.open('/tmp/afileToRead.txt', 'r')
+    output = file.read()
+    file.close()
+    sftp.close()
+    return output
+
 def test_example_function_sftp_write():
     ssh_mock = SSHClientMock()
 
@@ -134,6 +152,19 @@ This example shows how to track multiple commands executed in a single SSH sessi
 ```python
 from ParamikoMock import SSHMockEnvron, SSHCommandMock
 from unittest.mock import patch
+
+def example_function_multiple_calls():
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    # Some example of connection
+    client.connect('some_host',
+                    port=22,
+                    username='root',
+                    password='root',
+                    banner_timeout=10)
+    client.exec_command('ls -l')
+    client.exec_command('ls -al')
 
 def test_example_function_verify_commands_were_called():
     ssh_mock = SSHClientMock()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='paramiko-mock',
-    version='0.0.3',
+    version='0.0.4',
     description='Mock for paramiko library',
     author='Caio Cominato, Daniel Beaudry',
     author_email='caiopetrellicominato@gmail.com',

--- a/src/ParamikoMock/sftp_mock.py
+++ b/src/ParamikoMock/sftp_mock.py
@@ -1,0 +1,21 @@
+class SFTPFileMock():
+    written = []
+    file_content = None
+
+    def close(self):
+        pass
+
+    def write(self, data):
+        self.written.append(data)
+    
+    def read(self, size=None):
+        return self.file_content
+    
+
+class SFTPClientMock():
+    sftp_file_mock = SFTPFileMock()
+    def open(self, filename, mode="r", bufsize=-1):
+        return self.sftp_file_mock
+    
+    def close(self):
+        pass

--- a/src/ParamikoMock/ssh_mock.py
+++ b/src/ParamikoMock/ssh_mock.py
@@ -2,6 +2,7 @@ from abc import abstractmethod, ABC
 from io import StringIO
 import re
 from paramiko.ssh_exception import BadHostKeyException, NoValidConnectionsError
+from .sftp_mock import SFTPClientMock
 
 # Singleton
 class SingletonMeta(type):
@@ -12,27 +13,6 @@ class SingletonMeta(type):
             instance = super().__call__(*args, **kwargs)
             cls._instances[cls] = instance
         return cls._instances[cls]
-
-class SFTPFileMock():
-    written = []
-    file_content = None
-
-    def close(self):
-        pass
-
-    def write(self, data):
-        self.written.append(data)
-    
-    def read(self, size=None):
-        return self.file_content
-
-class SFTPClientMock():
-    sftp_file_mock = SFTPFileMock()
-    def open(self, filename, mode="r", bufsize=-1):
-        return self.sftp_file_mock
-    
-    def close(self):
-        pass
 
 class SSHClientMock():
     sftp_client_mock = SFTPClientMock()
@@ -50,7 +30,26 @@ class SSHClientMock():
     def open_sftp(self):
         return self.sftp_client_mock
     
-    def connect(self, host, port, username, password, banner_timeout):
+    def set_log_channel(self, log_channel):
+        pass
+    
+    def get_host_keys(self):
+        pass
+    
+    def save_host_keys(self, filename):
+        pass
+    
+    def load_host_keys(self, filename):
+        pass
+    
+    def load_system_host_keys(self, filename=None):
+        pass
+    
+    def connect(
+        self, host, 
+        port=22, username=None, password=None, 
+        **kwargs
+    ):
         self.selected_host = f'{host}:{port}'
         if self.selected_host not in SSHMockEnvron().commands_response:
             raise BadHostKeyException(host, None, 'No valid responses for this host')
@@ -59,12 +58,13 @@ class SSHClientMock():
             if set_credentials != (username, password):
                 raise BadHostKeyException(host, None, 'Invalid credentials')
         self.command_responses = SSHMockEnvron().commands_response[self.selected_host]
+        self.init_kwargs = kwargs
         self.clear_called_commands()
 
     def clear_called_commands(self):
         self.called.clear()
     
-    def exec_command(self, command):
+    def exec_command(self, command, bufsize=-1, timeout=None, get_pty=False, environment=None):
         if self.selected_host is None:
             raise NoValidConnectionsError('No valid connections')
         self.called.append(command)
@@ -80,6 +80,9 @@ class SSHClientMock():
             if response is None:
                 raise NotImplementedError('No valid response for this command')
         return response(self, command)
+    
+    def invoke_shell(self, term='vt100', width=80, height=24, width_pixels=0, height_pixels=0, environment=None):
+        pass
     
     def close(self):
         self.selected_commands = None

--- a/tests/test_mock_paramiko.py
+++ b/tests/test_mock_paramiko.py
@@ -1,6 +1,7 @@
 import paramiko
 from io import StringIO
-from src.ParamikoMock.ssh_mock import SSHClientMock, SSHCommandMock, SSHMockEnvron, SSHCommandFunctionMock, SFTPFileMock
+from src.ParamikoMock.ssh_mock import SSHClientMock, SSHCommandMock, SSHMockEnvron, SSHCommandFunctionMock
+from src.ParamikoMock.sftp_mock import SFTPClientMock, SFTPFileMock 
 from unittest.mock import patch
 
 def example_function_1():


### PR DESCRIPTION
This pull request includes updates to the `paramiko-mock` library, focusing on version updates, refactoring, and enhancements to the SFTP and SSH client mocks. The most important changes include version bump, refactoring to separate SFTP mocks into their own file, and adding new methods to the SSH client mock.

Version update:
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L13-R13): Updated the version of the `paramiko-mock` library from `0.0.3` to `0.0.4`.

Refactoring:
* [`src/ParamikoMock/sftp_mock.py`](diffhunk://#diff-370c3460103cf2a61d873997fcb8d480bcde22d07b37de5aa53cc75a535cea38R1-R21): Created a new file to house the `SFTPFileMock` and `SFTPClientMock` classes, moving them out of `ssh_mock.py` for better separation of concerns.

Enhancements to SSH client mock:
* [`src/ParamikoMock/ssh_mock.py`](diffhunk://#diff-3cf285623e8d9cefe74270fbf918144da8370aef8ffcd486babb67fdea326c45L53-R52): Added multiple new methods to the `SSHClientMock` class, including `set_log_channel`, `get_host_keys`, `save_host_keys`, `load_host_keys`, `load_system_host_keys`, and `invoke_shell`. These methods improve the mock's functionality and align it more closely with the actual `paramiko` library. [[1]](diffhunk://#diff-3cf285623e8d9cefe74270fbf918144da8370aef8ffcd486babb67fdea326c45L53-R52) [[2]](diffhunk://#diff-3cf285623e8d9cefe74270fbf918144da8370aef8ffcd486babb67fdea326c45R84-R86)

Test updates:
* [`tests/test_mock_paramiko.py`](diffhunk://#diff-5cd3d51884b192b0324c22a5fef552c204af1cf4fb1c78bf0c5d96372c2908d0L3-R4): Updated imports to reflect the new location of `SFTPFileMock` and `SFTPClientMock` in `sftp_mock.py`.