### PR TITLE
Fix/issue 18

### DIFF
--- a/src/ParamikoMock/ssh_mock.py
+++ b/src/ParamikoMock/ssh_mock.py
@@ -58,7 +58,7 @@ class SSHClientMock():
             if set_credentials != (username, password):
                 raise BadHostKeyException(host, None, 'Invalid credentials')
         self.command_responses = SSHMockEnvron().commands_response[self.selected_host]
-        self.init_kwargs = kwargs
+        self.connect_kwargs = kwargs
         self.clear_called_commands()
 
     def clear_called_commands(self):

--- a/src/ParamikoMock/ssh_mock.py
+++ b/src/ParamikoMock/ssh_mock.py
@@ -58,7 +58,7 @@ class SSHClientMock():
             if set_credentials != (username, password):
                 raise BadHostKeyException(host, None, 'Invalid credentials')
         self.command_responses = SSHMockEnvron().commands_response[self.selected_host]
-        self.connect_kwargs = kwargs
+        self.last_connect_kwargs = kwargs
         self.clear_called_commands()
 
     def clear_called_commands(self):


### PR DESCRIPTION
This pull request includes a change to the `connect` method in the `src/ParamikoMock/ssh_mock.py` file. The change renames the `init_kwargs` variable to `last_connect_kwargs` to better reflect its purpose.

* [`src/ParamikoMock/ssh_mock.py`](diffhunk://#diff-3cf285623e8d9cefe74270fbf918144da8370aef8ffcd486babb67fdea326c45L61-R61): Renamed `init_kwargs` to `last_connect_kwargs` in the `connect` method to improve code clarity.